### PR TITLE
Added missing header

### DIFF
--- a/primus_vk.cpp
+++ b/primus_vk.cpp
@@ -1,5 +1,6 @@
 #include "vulkan.h"
 #include "vk_layer.h"
+#include "vk_layer_dispatch_table.h"
 
 #include <xcb/xcb.h>
 #include <vulkan/vulkan_xcb.h>


### PR DESCRIPTION
Hello,

I needed this missing header (perhaps the latest SDK has shuffled the headers about?) to compile here on Ubuntu 18.04 with Vulkan 1.1.85. 

Cheers.