### PR TITLE
Respect external LDFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,10 @@ CXXFLAGS += -std=gnu++11 -g3
 all: libprimus_vk.so libnv_vulkan_wrapper.so
 
 libprimus_vk.so: primus_vk.cpp
-	g++ $(CXXFLAGS) -I/usr/include/vulkan -shared -fPIC $^ -o $@
+	g++ $(CXXFLAGS) -I/usr/include/vulkan -shared -fPIC $^ -o $@ $(LDFLAGS)
 
 libnv_vulkan_wrapper.so: nv_vulkan_wrapper.cpp
-	g++ $(CXXFLAGS) -I/usr/include/vulkan -shared -fPIC $^ -o $@
+	g++ $(CXXFLAGS) -I/usr/include/vulkan -shared -fPIC $^ -o $@ $(LDFLAGS)
 
 primus_vk_forwarding.h:
 	xsltproc surface_forwarding_functions.xslt /usr/share/vulkan/registry/vk.xml | tail -n +2 > $@
@@ -28,7 +28,7 @@ primus_vk_forwarding_prototypes.h:
 primus_vk.cpp: primus_vk_forwarding.h primus_vk_forwarding_prototypes.h
 
 primus_vk_diag: primus_vk_diag.o
-	g++ -g3 -o $@ $^ -lX11 -lvulkan -ldl
+	g++ -g3 -o $@ $^ -lX11 -lvulkan -ldl $(LDFLAGS)
 
 install:
 	$(INSTALL) "libnv_vulkan_wrapper.so" \


### PR DESCRIPTION
This is required for distro packaging, especially Arch `namcap` currently outputs:
```
primus_vk W: ELF file ('usr/bin/primus_vk_diag') lacks FULL RELRO, check LDFLAGS.
primus_vk W: ELF file ('usr/lib/libnv_vulkan_wrapper.so') lacks FULL RELRO, check LDFLAGS.
primus_vk W: ELF file ('usr/lib/libprimus_vk.so') lacks FULL RELRO, check LDFLAGS.
```