### PR TITLE
getImageMemories() return explicit tuple

### DIFF
--- a/primus_vk.cpp
+++ b/primus_vk.cpp
@@ -936,7 +936,7 @@ std::tuple<ssize_t, ssize_t, ssize_t> PrimusSwapchain::getImageMemories(){
   }
   TRACE("Selected render mem: " << render_host_mem << ";" << render_local_mem << " display: " << display_host_mem);
 
-  return {render_local_mem, render_host_mem, display_host_mem};
+  return std::make_tuple(render_local_mem, render_host_mem, display_host_mem);
 }
 
 void ImageWorker::createCommandBuffers(){


### PR DESCRIPTION
Updated the return statement in PrimusSwapchain::getImageMemories() to explicitly create a tuple, instead of using an initializer list.
This allows make to compile using make, instead of stopping the compile with an error message.