### PR TITLE
Performance improvements by using VK_MEMORY_PROPERTY_HOST_CACHED_BIT for render_host_mem

### DIFF
--- a/primus_vk.cpp
+++ b/primus_vk.cpp
@@ -455,7 +455,7 @@ struct ImageWorker {
   ~ImageWorker();
   void initImages( std::tuple<ssize_t, ssize_t, ssize_t> image_memory_types, const VkSwapchainCreateInfoKHR &createInfo);
   void createCommandBuffers();
-  void copyImageData(std::vector<VkSemaphore> sems);
+  void copyImageData(uint32_t idx, std::vector<VkSemaphore> sems);
 };
 struct PrimusSwapchain{
   InstanceInfo &myInstance;
@@ -1053,7 +1053,7 @@ void PrimusSwapchain::storeImage(uint32_t index, VkQueue queue, std::vector<VkSe
   images[index].render_copy_command->submit(queue, notify.fence, wait_on);
 }
 
-void ImageWorker::copyImageData(std::vector<VkSemaphore> sems){
+void ImageWorker::copyImageData(uint32_t index, std::vector<VkSemaphore> sems){
   {
     auto rendered = render_copy_image->getMapped();
     auto display = display_src_image->getMapped();
@@ -1117,7 +1117,7 @@ void PrimusSwapchain::present(const QueueItem &workItem){
     const auto index = workItem.imgIndex;
     images[index].render_copy_fence.await();
     images[index].render_copy_fence.reset();
-    images[index].copyImageData({images[index].display_semaphore.sem});
+    images[index].copyImageData(index, {images[index].display_semaphore.sem});
 
     TRACE_PROFILING_EVENT(index, "copy queued");
 

--- a/primus_vk.cpp
+++ b/primus_vk.cpp
@@ -955,21 +955,22 @@ VkResult VKAPI_CALL PrimusVK_GetSwapchainStatusKHR(VkDevice device, VkSwapchainK
 }
 
 std::tuple<ssize_t, ssize_t, ssize_t> PrimusSwapchain::getImageMemories(){
-  VkMemoryPropertyFlags host_mem = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
-  VkMemoryPropertyFlags local_mem = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+  VkMemoryPropertyFlags render_host_mem_flags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT;
+  VkMemoryPropertyFlags display_host_mem_flags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+  VkMemoryPropertyFlags local_mem_flags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
   ssize_t render_host_mem = -1;
   ssize_t render_local_mem = -1;
   ssize_t display_host_mem = -1;
   for(size_t j=0; j < cod->render_mem.memoryTypeCount; j++){
-    if ( render_host_mem == -1 && ( cod->render_mem.memoryTypes[j].propertyFlags & host_mem ) == host_mem ) {
+    if ( render_host_mem == -1 && ( cod->render_mem.memoryTypes[j].propertyFlags & render_host_mem_flags ) == render_host_mem_flags ) {
       render_host_mem = j;
     }
-    if ( render_local_mem == -1 && ( cod->render_mem.memoryTypes[j].propertyFlags & local_mem ) == local_mem ) {
+    if ( render_local_mem == -1 && ( cod->render_mem.memoryTypes[j].propertyFlags & local_mem_flags ) == local_mem_flags ) {
       render_local_mem = j;
     }
   }
   for(size_t j=0; j < cod->display_mem.memoryTypeCount; j++){
-    if ( display_host_mem == -1 && ( cod->display_mem.memoryTypes[j].propertyFlags & host_mem ) == host_mem ) {
+    if ( display_host_mem == -1 && ( cod->display_mem.memoryTypes[j].propertyFlags & display_host_mem_flags ) == display_host_mem_flags ) {
       display_host_mem = j;
     }
   }


### PR DESCRIPTION
When I am running thehunter call of the wild, the fps is stuck in the ~10 range, and gpu utilization from nvidia-smi is about 30%. I performed profiling, and discovered most of the time is spent in memcpy (Maybe that's because I am using a 4K screen?).
  
I found on the internet that reading from a mapped vulkan memory object created with VK_MEMORY_PROPERTY_HOST_COHERENT_BIT is very slow. Since render_host_mem will only be read from the host, maybe there's no need for VK_MEMORY_PROPERTY_HOST_COHERENT_BIT. 

I tried changing VK_MEMORY_PROPERTY_HOST_COHERENT_BIT to VK_MEMORY_PROPERTY_HOST_CACHED_BIT. That greatly reduced the time spent in memcpy. (I forgot the exact number, but it's several magnitudes of reduction.) memcpy is no longer the bottleneck, my fps jumps to ~30, and my gpu utilization become 100%.  

I am new to vulkan, and I am not sure if this is the correct thing to do. It does provide significant performance improvements though, and the game still runs correctly.

Hardware: 
Display GPU: Radeon Pro WX 5100
Render GPU: GeForce RTX 2080 Ti